### PR TITLE
Update NetworkManagementService.java

### DIFF
--- a/services/core/java/com/android/server/NetworkManagementService.java
+++ b/services/core/java/com/android/server/NetworkManagementService.java
@@ -734,7 +734,7 @@ public class NetworkManagementService extends INetworkManagementService.Stub
                         timestampNanos = SystemClock.elapsedRealtimeNanos();
                     }
                     boolean isActive = cooked[2].equals("active");
-                    notifyInterfaceClassActivity(Integer.parseInt(cooked[3]),
+                    notifyInterfaceClassActivity(cooked[3] == null ? 0 : Integer.parseInt(cooked[3]),
                             isActive ? DataConnectionRealTimeInfo.DC_POWER_STATE_HIGH
                             : DataConnectionRealTimeInfo.DC_POWER_STATE_LOW, timestampNanos, false);
                     return true;


### PR DESCRIPTION
Fix NPE in NetdResponseCode.InterfaceClassActivity

Under circumstances the 4th param is null and causes NPE.
Exception looks like this in logcat:
E/NetdConnector( 1086): Error handling '613 IfaceClass idle (null)':
java.lang.NumberFormatException: Invalid int: "(null)"
